### PR TITLE
Fix the twitching of the toggles on setting those

### DIFF
--- a/api-mock/locations/wl-page=1.json
+++ b/api-mock/locations/wl-page=1.json
@@ -1,1 +1,2717 @@
-{"provider": {"name": "Deltares", "supportUrl": "https://www.delft-fews.nl/", "apiVersion": "2.0", "responseTimestamp": "2019-04-26T10:15:18.775Z"}, "paging": {"totalObjectCount": 17467, "prev": null, "next": "http://localhost:5000/locations?pageSize=100&page=2", "minPageSize": 1, "maxPageSize": 100}, "results": [{"type": "Feature", "geometry": {"type": "Point", "coordinates": [-16.8457, 12.7865, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__1", "locationName": "diva_id__1", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-179.941, -16.5104, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__2", "locationName": "diva_id__2", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [1.46484, 50.1302, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__3", "locationName": "diva_id__3", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [103.975, 1.43229, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__4", "locationName": "diva_id__4", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [1.02539, 49.9219, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__5", "locationName": "diva_id__5", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [13.8867, 54.0365, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__6", "locationName": "diva_id__6", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-70.752, 47.0573, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__7", "locationName": "diva_id__7", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [1.08398, 49.974, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__8", "locationName": "diva_id__8", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-165.879, 54.1927, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__9", "locationName": "diva_id__9", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [1.23047, 49.974, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__10", "locationName": "diva_id__10", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.146484, 49.6094, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__11", "locationName": "diva_id__11", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-151.465, -16.5625, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__12", "locationName": "diva_id__12", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.205078, 49.7135, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__13", "locationName": "diva_id__13", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-138.516, -17.2917, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__14", "locationName": "diva_id__14", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.322266, 49.7656, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__15", "locationName": "diva_id__15", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-65.8301, 18.0469, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__16", "locationName": "diva_id__16", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.673828, 49.8698, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__18", "locationName": "diva_id__18", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [91.9922, 79.401, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__19", "locationName": "diva_id__19", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.0878906, 49.5573, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__20", "locationName": "diva_id__20", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-3.80859, 5.26042, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__21", "locationName": "diva_id__21", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.0878906, 49.5573, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__22", "locationName": "diva_id__22", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [137.783, -33.2552, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__23", "locationName": "diva_id__23", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [9.46289, 0.338542, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__24", "locationName": "diva_id__24", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.146484, 49.6094, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__25", "locationName": "diva_id__25", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [168.223, -15.4688, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__26", "locationName": "diva_id__26", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [35.4199, -23.776, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__27", "locationName": "diva_id__27", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.410156, 49.7656, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__28", "locationName": "diva_id__28", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [44.9414, 10.4688, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__29", "locationName": "diva_id__29", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-0.0878906, 49.2969, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__30", "locationName": "diva_id__30", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [47.3144, 13.6198, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__31", "locationName": "diva_id__31", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.0292969, 49.349, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__32", "locationName": "diva_id__32", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [59.3848, 25.4427, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__33", "locationName": "diva_id__33", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.0292969, 49.401, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__34", "locationName": "diva_id__34", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [75.498, 11.6927, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__35", "locationName": "diva_id__35", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.0292969, 49.401, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__36", "locationName": "diva_id__36", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [83.291, 17.6823, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__37", "locationName": "diva_id__37", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [0.0878906, 49.5573, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__38", "locationName": "diva_id__38", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [93.3105, 20.026, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__39", "locationName": "diva_id__39", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-0.439453, 49.349, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__40", "locationName": "diva_id__40", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-0.322266, 49.2969, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__41", "locationName": "diva_id__41", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [102.92, 11.6406, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__42", "locationName": "diva_id__42", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-0.205078, 49.2969, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__43", "locationName": "diva_id__43", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [108.193, 16.1198, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__44", "locationName": "diva_id__44", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-0.673828, 49.349, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__45", "locationName": "diva_id__45", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [114.99, 22.6823, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__46", "locationName": "diva_id__46", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.02539, 49.401, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__47", "locationName": "diva_id__47", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [121.963, 36.9531, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__48", "locationName": "diva_id__48", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.08398, 49.349, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__49", "locationName": "diva_id__49", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [132.275, 43.2031, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__50", "locationName": "diva_id__50", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.20117, 49.4531, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__51", "locationName": "diva_id__51", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [139.805, 72.1094, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__52", "locationName": "diva_id__52", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.9043, 49.6615, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__53", "locationName": "diva_id__53", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [72.7148, 69.974, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__54", "locationName": "diva_id__54", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.69922, 49.6615, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__55", "locationName": "diva_id__55", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [6.15234, 60.2344, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__56", "locationName": "diva_id__56", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.58203, 49.6354, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__57", "locationName": "diva_id__57", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [17.168, 61.0677, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__58", "locationName": "diva_id__58", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.58203, 49.6354, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__59", "locationName": "diva_id__59", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.25977, 49.6615, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__60", "locationName": "diva_id__60", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [5.80078, 53.3594, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__61", "locationName": "diva_id__61", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.61133, 49.2448, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__62", "locationName": "diva_id__62", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [3.33984, 51.3802, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__63", "locationName": "diva_id__63", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.55273, 48.9323, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__64", "locationName": "diva_id__64", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [158.115, 6.84896, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__65", "locationName": "diva_id__65", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.61133, 48.8281, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__66", "locationName": "diva_id__66", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-161.895, 58.6198, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__67", "locationName": "diva_id__67", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.49414, 48.6719, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__68", "locationName": "diva_id__68", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-123.457, 48.151, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__69", "locationName": "diva_id__69", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.49414, 48.6198, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__70", "locationName": "diva_id__70", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-122.314, 37.5781, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__71", "locationName": "diva_id__71", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-89.6191, 13.5156, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__75", "locationName": "diva_id__75", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-2.40234, 48.6979, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__76", "locationName": "diva_id__76", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-80.8887, -1.01562, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__77", "locationName": "diva_id__77", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-2.05078, 48.6719, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__78", "locationName": "diva_id__78", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.8457, 48.6198, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__79", "locationName": "diva_id__79", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-70.752, 42.5781, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__80", "locationName": "diva_id__80", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.96289, 48.6719, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__81", "locationName": "diva_id__81", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-74.0918, 39.8698, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__82", "locationName": "diva_id__82", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.96289, 48.6719, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__83", "locationName": "diva_id__83", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-76.377, 39.1406, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__84", "locationName": "diva_id__84", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-1.8457, 48.6198, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__85", "locationName": "diva_id__85", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-80.6543, 32.1615, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__86", "locationName": "diva_id__86", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-2.90039, 48.724, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__87", "locationName": "diva_id__87", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-82.6465, 27.4219, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__88", "locationName": "diva_id__88", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-2.7832, 48.5677, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__89", "locationName": "diva_id__89", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-88.0371, 30.2344, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__90", "locationName": "diva_id__90", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-2.72461, 48.5677, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__91", "locationName": "diva_id__91", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-43.6816, -23.0469, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__92", "locationName": "diva_id__92", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-3.33984, 48.8021, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__93", "locationName": "diva_id__93", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-73.2129, 11.3802, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__94", "locationName": "diva_id__94", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-3.89921, 48.6979, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__95", "locationName": "diva_id__95", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-46.5527, -0.963541, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__96", "locationName": "diva_id__96", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-4.54102, 48.6198, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__97", "locationName": "diva_id__97", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-130.43, 54.7135, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__99", "locationName": "diva_id__99", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-4.6582, 48.3073, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__100", "locationName": "diva_id__100", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-124.658, 49.8177, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__101", "locationName": "diva_id__101", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-4.59961, 48.2552, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__102", "locationName": "diva_id__102", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-99.9609, 78.6719, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__103", "locationName": "diva_id__103", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-4.27734, 48.151, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__104", "locationName": "diva_id__104", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}, {"type": "Feature", "geometry": {"type": "Point", "coordinates": [-94.8047, 75.8073, 0.0]}, "properties": {"node": {"url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares", "id": "Deltares", "name": "Deltares Digitale Delta"}, "locationId": "diva_id__105", "locationName": "diva_id__105", "referenceLevel": "m", "crs": {"type": "name", "properties": {"name": "EPSG:4326"}}}}]}
+{
+  "provider": {
+    "name": "Deltares",
+    "supportUrl": "https://www.delft-fews.nl/",
+    "apiVersion": "2.0",
+    "responseTimestamp": "2019-04-26T10:15:18.775Z"
+  },
+  "paging": {
+    "totalObjectCount": 100,
+    "prev": null,
+    "next": "http://localhost:5000/locations?pageSize=100&page=2",
+    "minPageSize": 1,
+    "maxPageSize": 100
+  },
+  "results": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -16.8457,
+          12.7865,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__1",
+        "locationName": "diva_id__1",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -179.941,
+          -16.5104,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__2",
+        "locationName": "diva_id__2",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          1.46484,
+          50.1302,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__3",
+        "locationName": "diva_id__3",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          103.975,
+          1.43229,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__4",
+        "locationName": "diva_id__4",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          1.02539,
+          49.9219,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__5",
+        "locationName": "diva_id__5",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.8867,
+          54.0365,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__6",
+        "locationName": "diva_id__6",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -70.752,
+          47.0573,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__7",
+        "locationName": "diva_id__7",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          1.08398,
+          49.974,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__8",
+        "locationName": "diva_id__8",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -165.879,
+          54.1927,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__9",
+        "locationName": "diva_id__9",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          1.23047,
+          49.974,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__10",
+        "locationName": "diva_id__10",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.146484,
+          49.6094,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__11",
+        "locationName": "diva_id__11",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -151.465,
+          -16.5625,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__12",
+        "locationName": "diva_id__12",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.205078,
+          49.7135,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__13",
+        "locationName": "diva_id__13",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -138.516,
+          -17.2917,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__14",
+        "locationName": "diva_id__14",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.322266,
+          49.7656,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__15",
+        "locationName": "diva_id__15",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -65.8301,
+          18.0469,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__16",
+        "locationName": "diva_id__16",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.673828,
+          49.8698,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__18",
+        "locationName": "diva_id__18",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          91.9922,
+          79.401,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__19",
+        "locationName": "diva_id__19",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.0878906,
+          49.5573,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__20",
+        "locationName": "diva_id__20",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -3.80859,
+          5.26042,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__21",
+        "locationName": "diva_id__21",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.0878906,
+          49.5573,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__22",
+        "locationName": "diva_id__22",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          137.783,
+          -33.2552,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__23",
+        "locationName": "diva_id__23",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.46289,
+          0.338542,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__24",
+        "locationName": "diva_id__24",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.146484,
+          49.6094,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__25",
+        "locationName": "diva_id__25",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          168.223,
+          -15.4688,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__26",
+        "locationName": "diva_id__26",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          35.4199,
+          -23.776,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__27",
+        "locationName": "diva_id__27",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.410156,
+          49.7656,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__28",
+        "locationName": "diva_id__28",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          44.9414,
+          10.4688,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__29",
+        "locationName": "diva_id__29",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.0878906,
+          49.2969,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__30",
+        "locationName": "diva_id__30",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          47.3144,
+          13.6198,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__31",
+        "locationName": "diva_id__31",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.0292969,
+          49.349,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__32",
+        "locationName": "diva_id__32",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          59.3848,
+          25.4427,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__33",
+        "locationName": "diva_id__33",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.0292969,
+          49.401,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__34",
+        "locationName": "diva_id__34",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          75.498,
+          11.6927,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__35",
+        "locationName": "diva_id__35",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.0292969,
+          49.401,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__36",
+        "locationName": "diva_id__36",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          83.291,
+          17.6823,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__37",
+        "locationName": "diva_id__37",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0.0878906,
+          49.5573,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__38",
+        "locationName": "diva_id__38",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          93.3105,
+          20.026,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__39",
+        "locationName": "diva_id__39",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.439453,
+          49.349,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__40",
+        "locationName": "diva_id__40",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.322266,
+          49.2969,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__41",
+        "locationName": "diva_id__41",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          102.92,
+          11.6406,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__42",
+        "locationName": "diva_id__42",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.205078,
+          49.2969,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__43",
+        "locationName": "diva_id__43",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          108.193,
+          16.1198,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__44",
+        "locationName": "diva_id__44",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -0.673828,
+          49.349,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__45",
+        "locationName": "diva_id__45",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          114.99,
+          22.6823,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__46",
+        "locationName": "diva_id__46",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.02539,
+          49.401,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__47",
+        "locationName": "diva_id__47",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          121.963,
+          36.9531,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__48",
+        "locationName": "diva_id__48",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.08398,
+          49.349,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__49",
+        "locationName": "diva_id__49",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          132.275,
+          43.2031,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__50",
+        "locationName": "diva_id__50",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.20117,
+          49.4531,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__51",
+        "locationName": "diva_id__51",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          139.805,
+          72.1094,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__52",
+        "locationName": "diva_id__52",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.9043,
+          49.6615,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__53",
+        "locationName": "diva_id__53",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          72.7148,
+          69.974,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__54",
+        "locationName": "diva_id__54",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.69922,
+          49.6615,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__55",
+        "locationName": "diva_id__55",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.15234,
+          60.2344,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__56",
+        "locationName": "diva_id__56",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.58203,
+          49.6354,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__57",
+        "locationName": "diva_id__57",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          17.168,
+          61.0677,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__58",
+        "locationName": "diva_id__58",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.58203,
+          49.6354,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__59",
+        "locationName": "diva_id__59",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.25977,
+          49.6615,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__60",
+        "locationName": "diva_id__60",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          5.80078,
+          53.3594,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__61",
+        "locationName": "diva_id__61",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.61133,
+          49.2448,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__62",
+        "locationName": "diva_id__62",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          3.33984,
+          51.3802,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__63",
+        "locationName": "diva_id__63",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.55273,
+          48.9323,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__64",
+        "locationName": "diva_id__64",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          158.115,
+          6.84896,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__65",
+        "locationName": "diva_id__65",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.61133,
+          48.8281,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__66",
+        "locationName": "diva_id__66",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -161.895,
+          58.6198,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__67",
+        "locationName": "diva_id__67",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.49414,
+          48.6719,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__68",
+        "locationName": "diva_id__68",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -123.457,
+          48.151,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__69",
+        "locationName": "diva_id__69",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.49414,
+          48.6198,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__70",
+        "locationName": "diva_id__70",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.314,
+          37.5781,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__71",
+        "locationName": "diva_id__71",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -89.6191,
+          13.5156,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__75",
+        "locationName": "diva_id__75",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.40234,
+          48.6979,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__76",
+        "locationName": "diva_id__76",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -80.8887,
+          -1.01562,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__77",
+        "locationName": "diva_id__77",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.05078,
+          48.6719,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__78",
+        "locationName": "diva_id__78",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.8457,
+          48.6198,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__79",
+        "locationName": "diva_id__79",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -70.752,
+          42.5781,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__80",
+        "locationName": "diva_id__80",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.96289,
+          48.6719,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__81",
+        "locationName": "diva_id__81",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.0918,
+          39.8698,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__82",
+        "locationName": "diva_id__82",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.96289,
+          48.6719,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__83",
+        "locationName": "diva_id__83",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -76.377,
+          39.1406,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__84",
+        "locationName": "diva_id__84",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -1.8457,
+          48.6198,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__85",
+        "locationName": "diva_id__85",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -80.6543,
+          32.1615,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__86",
+        "locationName": "diva_id__86",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.90039,
+          48.724,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__87",
+        "locationName": "diva_id__87",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -82.6465,
+          27.4219,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__88",
+        "locationName": "diva_id__88",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.7832,
+          48.5677,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__89",
+        "locationName": "diva_id__89",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -88.0371,
+          30.2344,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__90",
+        "locationName": "diva_id__90",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -2.72461,
+          48.5677,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__91",
+        "locationName": "diva_id__91",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -43.6816,
+          -23.0469,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__92",
+        "locationName": "diva_id__92",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -3.33984,
+          48.8021,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__93",
+        "locationName": "diva_id__93",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -73.2129,
+          11.3802,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__94",
+        "locationName": "diva_id__94",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -3.89921,
+          48.6979,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__95",
+        "locationName": "diva_id__95",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -46.5527,
+          -0.963541,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__96",
+        "locationName": "diva_id__96",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -4.54102,
+          48.6198,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__97",
+        "locationName": "diva_id__97",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -130.43,
+          54.7135,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__99",
+        "locationName": "diva_id__99",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -4.6582,
+          48.3073,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__100",
+        "locationName": "diva_id__100",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -124.658,
+          49.8177,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__101",
+        "locationName": "diva_id__101",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -4.59961,
+          48.2552,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__102",
+        "locationName": "diva_id__102",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -99.9609,
+          78.6719,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__103",
+        "locationName": "diva_id__103",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -4.27734,
+          48.151,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__104",
+        "locationName": "diva_id__104",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -94.8047,
+          75.8073,
+          0
+        ]
+      },
+      "properties": {
+        "node": {
+          "url": "http://pl-tc012.xtr.deltares.nl:8080/FewsWebServices/rest/digitaledelta/2.0/nodes/Deltares",
+          "id": "Deltares",
+          "name": "Deltares Digitale Delta"
+        },
+        "locationId": "diva_id__105",
+        "locationName": "diva_id__105",
+        "referenceLevel": "m",
+        "crs": {
+          "type": "name",
+          "properties": {
+            "name": "EPSG:4326"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -66,6 +66,16 @@ export default {
       }
     },
   },
+  watch: {
+    $route: {
+      handler(routeObj) {
+        if (routeObj.params.datasetIds === undefined) {
+          this.clearActiveDatasetIds()
+        }
+      },
+      deep: true,
+    },
+  },
   methods: {
     ...mapActions('map', ['loadPointDataForLocation']),
     ...mapMutations('map', ['clearActiveDatasetIds']),
@@ -104,11 +114,6 @@ export default {
         toggleIdDatasets,
         this.$route,
       )
-
-      if (newRouteObject.params.datasetIds === undefined) {
-        this.clearActiveDatasetIds()
-      }
-
       this.updateRoute(newRouteObject)
     },
     updateRoute(routeObj) {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -68,6 +68,7 @@ export default {
   },
   methods: {
     ...mapActions('map', ['loadPointDataForLocation']),
+    ...mapMutations('map', ['clearActiveDatasetIds']),
     ...mapMutations({ setActiveTheme: 'preferences/theme/setActive' }),
     loadLocations({ detail }) {
       const locationIds = detail.map(feature => feature.properties.locationId)
@@ -103,6 +104,10 @@ export default {
         toggleIdDatasets,
         this.$route,
       )
+
+      if (newRouteObject.params.datasetIds === undefined) {
+        this.clearActiveDatasetIds()
+      }
 
       this.updateRoute(newRouteObject)
     },

--- a/pages/_datasetIds.vue
+++ b/pages/_datasetIds.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-import { mapActions, mapMutations } from 'vuex'
+import { mapActions } from 'vuex'
 
 export default {
   middleware: 'load-dataset-ids',
@@ -15,15 +15,11 @@ export default {
       this.loadLocationsInDatasets(datasetIds)
     }
   },
-  destroyed() {
-    this.clearActiveDatasetIds()
-  },
   methods: {
     ...mapActions('map', [
       'loadLocationsInDatasets',
       'loadPointDataForLocation',
     ]),
-    ...mapMutations('map', ['clearActiveDatasetIds']),
   },
 }
 </script>

--- a/test/unit/layouts/default.spec.js
+++ b/test/unit/layouts/default.spec.js
@@ -21,9 +21,13 @@ describe('Default', () => {
         activeDatasetsLocations: jest.fn(() => 'foo'),
         activeSpatialData: jest.fn(() => 'foo'),
         datasetsInActiveTheme: jest.fn(() => ['bar']),
+        activeTimestamp: jest.fn(),
       },
       actions: {
         loadPointDataForLocation: jest.fn(),
+      },
+      mutations: {
+        clearActiveDatasetIds: jest.fn(),
       },
     }
     preferences = {


### PR DESCRIPTION
This is implemented by clearing the active dataset ids on a layout level
instead of a page level. The page got destroyed even when the same page
was opend right after. Because the page was destroyed, all active
datasets were cleared instead of the one being toggled