### PR TITLE
Feat/bed 404 reset settings button

### DIFF
--- a/components/data-set-controls.vue
+++ b/components/data-set-controls.vue
@@ -20,7 +20,7 @@
               @click="toggleRasterLayer(dataset.id)"
             />
           </div>
-          <div v-if="dataset.toolTip" @click="onTooltipClick(dataset.id)" class="tooltip">
+          <div v-if="dataset.toolTip" class="tooltip" @click="onTooltipClick(dataset.id)">
             <icon name="info" />
           </div>
         </div>

--- a/components/navigation-bar/navigation-bar.vue
+++ b/components/navigation-bar/navigation-bar.vue
@@ -4,10 +4,10 @@
     @transitionend="onTransitionEnd"
     class="navigation-bar"
   >
-    <div class="navigation-bar__logo">
-      <icon v-show="!sidebarExpanded" name="deltares" size="large" />
+    <ui-button-icon class="navigation-bar__logo" kind="quiet" @click="resetSettings">
+      <icon name="deltares" size="large" />
       <span class="ui-button-icon__label bodytext-m">Deltares</span>
-    </div>
+    </ui-button-icon>
 
     <ul class="navigation-bar__list">
       <li v-for="(theme, key) in getThemes" :key="key">
@@ -71,6 +71,8 @@
       },
       onTransitionEnd() {
         this.$store.commit('preferences/setSidebarAnimating', { animating: false })
+      },
+      resetSettings() {
       },
       toggleTheme(id) {
         this.toggleActiveTheme(id)
@@ -180,6 +182,11 @@
   .navigation-bar__logo img {
     width: 32px;
     padding: 0.125rem;
+  }
+
+  .navigation-bar__logo .icon {
+    width: 30px;
+    height: 30px;
   }
 
   .navigation-bar__list {

--- a/components/navigation-bar/navigation-bar.vue
+++ b/components/navigation-bar/navigation-bar.vue
@@ -65,7 +65,7 @@
       },
     },
     methods: {
-      ...mapMutations('map', ['resetMap', 'toggleActiveTheme']),
+      ...mapMutations('map', ['resetMap', 'setActiveRasterLayer', 'toggleActiveTheme']),
       ...mapMutations('preferences', ['resetPreferences']),
       isActive(id) {
         return this.activeTheme === id
@@ -76,6 +76,7 @@
       resetSettings() {
         this.resetMap()
         this.resetPreferences()
+        this.setActiveRasterLayer('gb')
 
         this.activeTheme = null
 

--- a/components/navigation-bar/navigation-bar.vue
+++ b/components/navigation-bar/navigation-bar.vue
@@ -65,7 +65,8 @@
       },
     },
     methods: {
-      ...mapMutations('map', ['toggleActiveTheme']),
+      ...mapMutations('map', ['resetMap', 'toggleActiveTheme']),
+      ...mapMutations('preferences', ['resetPreferences']),
       isActive(id) {
         return this.activeTheme === id
       },
@@ -73,6 +74,12 @@
         this.$store.commit('preferences/setSidebarAnimating', { animating: false })
       },
       resetSettings() {
+        this.resetMap()
+        this.resetPreferences()
+
+        this.activeTheme = null
+
+        this.$router.push({ path: '/' })
       },
       toggleTheme(id) {
         this.toggleActiveTheme(id)

--- a/components/navigation-bar/navigation-bar.vue
+++ b/components/navigation-bar/navigation-bar.vue
@@ -1,8 +1,8 @@
 <template>
   <nav
     :class="{ 'navigation-bar--expanded': sidebarExpanded }"
-    @transitionend="onTransitionEnd"
     class="navigation-bar"
+    @transitionend="onTransitionEnd"
   >
     <ui-button-icon class="navigation-bar__logo" kind="quiet" @click="resetSettings">
       <icon name="deltares" size="large" />
@@ -14,8 +14,8 @@
         <div class="navigation-bar__list-item">
           <ui-button-icon
             :class="{ 'ui-button-icon--active': isActive(theme.id) }"
-            @click="toggleTheme(theme.id)"
             kind="quiet"
+            @click="toggleTheme(theme.id)"
           >
             <icon :name="`theme-${theme.id}`" />
             <span class="ui-button-icon__label bodytext-m">{{ theme.name }}</span>

--- a/components/navigation-bar/navigation-bar.vue
+++ b/components/navigation-bar/navigation-bar.vue
@@ -60,6 +60,7 @@
     computed: {
       ...mapGetters('map/themes', ['getThemes', 'getActiveTheme']),
       ...mapState('preferences', ['sidebarExpanded']),
+      ...mapState('map', ['defaultRasterLayerId']),
       logo() {
         return require('~/assets/images/deltares_avatar.png')
       },
@@ -76,7 +77,7 @@
       resetSettings() {
         this.resetMap()
         this.resetPreferences()
-        this.setActiveRasterLayer('gb')
+        this.setActiveRasterLayer(this.defaultRasterLayerId)
 
         this.activeTheme = null
 

--- a/store/map/index.js
+++ b/store/map/index.js
@@ -16,7 +16,7 @@ import getFromApi from '../../lib/request/get'
 
 const getId = get('id')
 
-export const state = () => ({
+export const getDefaultState = () => ({
   activeDatasetIds: [],
   activeLocationIds: [],
   activeRasterLayerId: '',
@@ -26,7 +26,12 @@ export const state = () => ({
   geographicalScope: '',
 })
 
+export const state = getDefaultState()
+
 export const mutations = {
+  resetMap(state) {
+    Object.assign(state, getDefaultState())
+  },
   setActiveDatasetIds(state, ids) {
     state.activeDatasetIds = ids
   },

--- a/store/map/index.js
+++ b/store/map/index.js
@@ -30,7 +30,11 @@ export const state = getDefaultState()
 
 export const mutations = {
   resetMap(state) {
-    Object.assign(state, getDefaultState())
+    state.activeDatasetIds = []
+    state.activeLocationIds = []
+    state.activeTheme = {}
+    state.collapsedDatasets = []
+    state.loadingRasterLayers = false
   },
   setActiveDatasetIds(state, ids) {
     state.activeDatasetIds = ids

--- a/store/map/index.js
+++ b/store/map/index.js
@@ -22,6 +22,7 @@ export const getDefaultState = () => ({
   activeRasterLayerId: '',
   activeTheme: {},
   collapsedDatasets: [],
+  defaultRasterLayerId: '',
   loadingRasterLayers: false,
   geographicalScope: '',
 })
@@ -63,6 +64,9 @@ export const mutations = {
   },
   setActiveRasterLayer(state, id) {
     state.activeRasterLayerId = id
+  },
+  setDefaultRasterLayer(state, id) {
+    state.defaultRasterLayerId = id
   },
   toggleCollapsedDataset(state, id) {
     // Updates the collapsedDatasets array, when id already exists in this Array
@@ -121,6 +125,7 @@ export const actions = {
           const rasterActive = _.get(set, 'rasterActiveOnLoad')
           if (rasterActive) {
             commit('setActiveRasterLayer', set.id)
+            commit('setDefaultRasterLayer', set.id)
           }
         }
       })

--- a/store/preferences/index.js
+++ b/store/preferences/index.js
@@ -1,10 +1,15 @@
-export const state = () => ({
+export const getDefaultState = () => ({
   sidebarAnimating: false,
   sidebarExpanded: false,
   user: null,
 })
 
+export const state = getDefaultState()
+
 export const mutations = {
+  resetPreferences(state) {
+    Object.assign(state, getDefaultState())
+  },
   setSidebarAnimating(state, { animating }) {
     state.sidebarAnimating = animating
   },

--- a/test/unit/store/map/index/index.spec.js
+++ b/test/unit/store/map/index/index.spec.js
@@ -10,5 +10,5 @@ test('Initial state', () => {
     loadingRasterLayers: false,
     geographicalScope: '',
   }
-  expect(state()).toEqual(initialState)
+  expect(state).toEqual(initialState)
 })

--- a/test/unit/store/map/index/index.spec.js
+++ b/test/unit/store/map/index/index.spec.js
@@ -7,6 +7,7 @@ test('Initial state', () => {
     activeRasterLayerId: '',
     activeTheme: {},
     collapsedDatasets: [],
+    defaultRasterLayerId: '',
     loadingRasterLayers: false,
     geographicalScope: '',
   }

--- a/test/unit/store/preferences/index/index.spec.js
+++ b/test/unit/store/preferences/index/index.spec.js
@@ -6,5 +6,5 @@ test('Initial state', () => {
     sidebarExpanded: false,
     user: null,
   }
-  expect(state()).toEqual(initialState)
+  expect(state).toEqual(initialState)
 })


### PR DESCRIPTION
This pull-request includes:
- Created a default state for both map and preferences, usable by calling `getDefaultState()` for both.
- Normal `state` uses new getDefaultState, so they are always equal.
- Logo is now a button which, on click, resets everything.