### PR TITLE
Feat/gdv 342 tour guide

### DIFF
--- a/components/data-set-controls.vue
+++ b/components/data-set-controls.vue
@@ -1,10 +1,14 @@
 <template>
-  <panel class="data-set-controls">
+  <panel class="data-set-controls" data-v-step="3">
     <template v-slot:header>
       <h3 class="h4">{{ themeName }}</h3>
     </template>
     <ul class="data-set-controls__list">
-      <li v-for="dataset in datasets" :key="dataset.id">
+      <li
+        v-for="(dataset, index) in datasets"
+        :key="dataset.id"
+        :data-v-step="index === 1 ? '4' : false"
+      >
         <div class="data-set-controls__item">
           <icon :name="`dataset-${dataset.id}`" />
           <span class="data-set-controls__item-title">{{ dataset.name }}</span>

--- a/components/graph-line.vue
+++ b/components/graph-line.vue
@@ -25,7 +25,7 @@
       <v-chart
         v-if="isLine || isScatter"
         :ref="title"
-        :options="options"
+        :options="graphData"
         :autoresize="true"
         class="graph-line__chart"
       />
@@ -200,9 +200,6 @@
       isCollapsed() {
         return this.getCollapsedDatasets.includes(this.parameterId)
       },
-      options() {
-        const series = this.graphData()
-        return series
       isLine() {
         return this.type === 'line'
       },

--- a/components/graph-line.vue
+++ b/components/graph-line.vue
@@ -5,7 +5,6 @@
       'graph-line--collapsed': isCollapsed,
     }"
     class="graph-line"
-    data-v-step="6"
   >
     <ui-button-icon
       v-if="collapsible"

--- a/components/graph-line.vue
+++ b/components/graph-line.vue
@@ -303,20 +303,13 @@
 </script>
 
 <style>
-  .graph-image {
-    height: 600px;
-    background-repeat: no-repeat;
-    background-size: 50% 100%;
-  }
-
   .graph-line {
     position: relative;
-    --caption-height: 3rem;
   }
 
   .graph-line__aspect-ratio {
     position: relative;
-    min-height: 360px;
+    min-height: 400px;
   }
 
   .graph-line__aspect-ratio--image {
@@ -328,7 +321,13 @@
     top: 0;
     left: 0;
     width: 100%;
-    height: 90%;
+    height: 85%;
+  }
+
+  .graph-line__image {
+    height: 600px;
+    background-repeat: no-repeat;
+    background-size: 50% 100%;
   }
 
   .graph-line__collapsible .graph-line__caption {
@@ -349,7 +348,7 @@
   }
 
   .graph-line__caption {
-    height: var(--caption-height);
+    height: 3rem;
     padding: var(--spacing-small);
     background-color: var(--color-background);
   }

--- a/components/graph-line.vue
+++ b/components/graph-line.vue
@@ -5,6 +5,7 @@
       'graph-line--collapsed': isCollapsed,
     }"
     class="graph-line"
+    data-v-step="6"
   >
     <ui-button-icon
       v-if="collapsible"

--- a/components/graph-line.vue
+++ b/components/graph-line.vue
@@ -17,17 +17,21 @@
     <figcaption class="graph-line__caption strong" @click="toggleCollapsedDataset(parameterId)">
       {{ title }}
     </figcaption>
-    <div v-if="!isCollapsed" :class="{ image: type === 'images' }" class="graph-line__aspect-ratio">
+    <div
+      v-if="!isCollapsed"
+      :class="{ 'graph-line__aspect-ratio--image': isImage }"
+      class="graph-line__aspect-ratio"
+    >
       <v-chart
-        v-if="type === 'line' || type === 'scatter'"
+        v-if="isLine || isScatter"
         :ref="title"
         :options="options"
         :autoresize="true"
         class="graph-line__chart"
       />
-      <img v-if="type === 'images'" :src="imageUrl" class="graph-line__chart graph-image" />
+      <img v-else :src="imageUrl" class="graph-line__image" />
       <ui-button
-        v-if="user && type !== 'images'"
+        v-if="user && (isLine || isScatter)"
         class="graph-line__download"
         kind="secondary"
         @click="downloadJson"
@@ -35,14 +39,14 @@
         Download data
       </ui-button>
       <ui-button
-        v-if="user && type === 'images'"
+        v-if="user && isImage"
         class="graph-line__download"
         kind="secondary"
         @click="downloadImage"
       >
         Download image
       </ui-button>
-      <p v-else class="graph-line__message">
+      <p v-if="!user" class="graph-line__message">
         <icon name="info" />
         Please log in to download data
       </p>
@@ -199,6 +203,14 @@
       options() {
         const series = this.graphData()
         return series
+      isLine() {
+        return this.type === 'line'
+      },
+      isImage() {
+        return this.type === 'images'
+      },
+      isScatter() {
+        return this.type === 'scatter'
       },
     },
     methods: {
@@ -294,10 +306,6 @@
 </script>
 
 <style>
-  .graph-line__aspect-ratio.image {
-    height: 600px;
-  }
-
   .graph-image {
     height: 600px;
     background-repeat: no-repeat;
@@ -312,6 +320,10 @@
   .graph-line__aspect-ratio {
     position: relative;
     min-height: 360px;
+  }
+
+  .graph-line__aspect-ratio--image {
+    height: 600px;
   }
 
   .graph-line__chart {

--- a/components/navigation-bar/navigation-bar.vue
+++ b/components/navigation-bar/navigation-bar.vue
@@ -37,7 +37,7 @@
         </ui-button-icon>
       </li>
       <li>
-        <ui-button-icon @click="toggleAccount">
+        <ui-button-icon @click="toggleAccount" data-v-step="6">
           <icon name="account" />
           <span class="ui-button-icon__label bodytext-m">Account</span>
         </ui-button-icon>

--- a/components/navigation-bar/navigation-bar.vue
+++ b/components/navigation-bar/navigation-bar.vue
@@ -37,7 +37,7 @@
         </ui-button-icon>
       </li>
       <li>
-        <ui-button-icon @click="toggleAccount" data-v-step="6">
+        <ui-button-icon data-v-step="6" @click="toggleAccount">
           <icon name="account" />
           <span class="ui-button-icon__label bodytext-m">Account</span>
         </ui-button-icon>

--- a/components/navigation-bar/navigation-bar.vue
+++ b/components/navigation-bar/navigation-bar.vue
@@ -18,7 +18,7 @@
       <li v-for="(theme, key) in getThemes" :key="key">
         <div class="navigation-bar__list-item">
           <ui-button-icon
-            :data-v-step="theme.name === 'Flooding' ? '2' : false"
+            :data-v-step="key === 'fl' ? '2' : false"
             :class="{ 'ui-button-icon--active': isActive(theme.id) }"
             @click="toggleTheme(theme.id)"
           >

--- a/components/navigation-bar/navigation-bar.vue
+++ b/components/navigation-bar/navigation-bar.vue
@@ -4,7 +4,12 @@
     class="navigation-bar"
     @transitionend="onTransitionEnd"
   >
-    <ui-button-icon class="navigation-bar__logo" kind="quiet" @click="resetSettings">
+    <ui-button-icon
+      data-v-step="1"
+      class="navigation-bar__logo"
+      kind="quiet"
+      @click="resetSettings"
+    >
       <icon name="deltares" size="large" />
       <span class="ui-button-icon__label bodytext-m">Deltares</span>
     </ui-button-icon>
@@ -13,6 +18,7 @@
       <li v-for="(theme, key) in getThemes" :key="key">
         <div class="navigation-bar__list-item">
           <ui-button-icon
+            :data-v-step="theme.name === 'Flooding' ? '2' : false"
             :class="{ 'ui-button-icon--active': isActive(theme.id) }"
             @click="toggleTheme(theme.id)"
           >

--- a/css/tour.css
+++ b/css/tour.css
@@ -1,0 +1,32 @@
+.default-layout .v-step {
+  background-color: var(--color-blue-100);
+  -webkit-filter: drop-shadow(0 2px 5px rgba(0, 0, 0, 0.5));
+  filter: drop-shadow(0 2px 5px rgba(0, 0, 0, 0.5));
+}
+
+.default-layout .v-step .v-step__arrow {
+  border-color: var(--color-blue-100);
+}
+
+.default-layout .v-step .v-step__content {
+  text-align: left;
+  font-size: 1rem;
+  line-height: 1.3rem;
+}
+
+.default-layout .v-step .v-step__buttons {
+  display: flex;
+}
+
+.default-layout .v-step .v-step__button-skip {
+  margin-right: auto;
+}
+
+.default-layout .v-step .v-step__button {
+  height: auto;
+  padding: 4px 8px;
+}
+
+.default-layout .v-step .v-step__button:hover {
+  color: var(--color-blue-100);
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -102,16 +102,8 @@
           coordinates: [],
         },
         mapboxMessage: '',
-        introductionCallbacks: {
-          onNextStep: this.stepCallback,
-          onPreviousStep: this.stepCallback,
-          onFinish: this.finishCallback,
-        },
         introductionOptions: {
           useKeyboardNavigation: true,
-          labels: {
-            buttonSkip: 'Skip introduction',
-          },
         },
         introductionSteps: [
           {
@@ -153,14 +145,14 @@
             target: '[data-v-step="6"]',
             content: 'You can download data if you are registered and logged in.',
             params: {
-              placement: 'bottom',
+              placement: 'right',
             },
           },
           {
             target: '[data-v-step="6"]',
             content: 'Have fun!',
             params: {
-              placement: 'bottom',
+              placement: 'right',
             },
           },
         ],
@@ -281,18 +273,6 @@
           type: 'Point',
           coordinates: [],
         }
-      },
-      stepCallback(step) {
-        if (step === 2) {
-          this.$router.push({ path: '/wl' })
-        }
-
-        if (step === 3) {
-          this.$router.push({ path: '/wl/diva_idp_med_10' })
-        }
-      },
-      finishCallback() {
-        this.$router.push({ path: '/' })
       },
       updateFilter(layer) {
         // if there is a filterIds, concatenate the values into filter

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -50,11 +50,7 @@
 
     <disclaimer-modal />
 
-    <v-tour
-      name="introductionTour"
-      :steps="introductionSteps"
-      :callbacks="introductionCallbacks"
-    ></v-tour>
+    <v-tour name="introductionTour" :steps="introductionSteps"></v-tour>
   </div>
 </template>
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -50,7 +50,7 @@
 
     <disclaimer-modal />
 
-    <v-tour name="introductionTour" :steps="introductionSteps"></v-tour>
+    <v-tour name="introduction" :steps="tourSteps" :options="tourConfig"></v-tour>
   </div>
 </template>
 
@@ -60,6 +60,7 @@
   import update from 'lodash/fp/update'
   import { mapState, mapGetters, mapMutations } from 'vuex'
   import auth from '../auth'
+  import { tourConfig, tourSteps } from '../plugins/vue-tour'
   import DataSetControls from '../components/data-set-controls'
   import TimeStamp from '../components/time-stamp'
   import getVectorLayer from '../lib/mapbox/layers/get-vector-layer'
@@ -85,6 +86,8 @@
       Sidebar,
     },
     data: () => ({
+      tourConfig,
+      tourSteps,
       mapboxAccessToken: process.env.MAPBOX_ACCESS_TOKEN,
       locationsLayers: [],
       activeLocation: null,
@@ -97,60 +100,6 @@
         coordinates: [],
       },
       mapboxMessage: '',
-      introductionOptions: {
-        useKeyboardNavigation: true,
-      },
-      introductionSteps: [
-        {
-          target: '[data-v-step="1"]',
-          content: 'Welcome to BlueEarth Data!',
-          params: {
-            placement: 'right',
-          },
-        },
-        {
-          target: '[data-v-step="2"]',
-          content: 'BlueEarth Data is organized by theme.',
-          params: {
-            placement: 'right',
-          },
-        },
-        {
-          target: '[data-v-step="3"]',
-          content: 'Datasets for each theme are listed here.',
-          params: {
-            placement: 'left',
-          },
-        },
-        {
-          target: '[data-v-step="4"]',
-          content: 'Toggle spatial maps and time series for each dataset.',
-          params: {
-            placement: 'bottom',
-          },
-        },
-        {
-          target: '[data-v-step="5"]',
-          content: 'Click on a data point on the map to see more details.',
-          params: {
-            placement: 'bottom',
-          },
-        },
-        {
-          target: '[data-v-step="6"]',
-          content: 'You can download data if you are registered and logged in.',
-          params: {
-            placement: 'right',
-          },
-        },
-        {
-          target: '[data-v-step="6"]',
-          content: 'Have fun!',
-          params: {
-            placement: 'right',
-          },
-        },
-      ],
     }),
     computed: {
       ...mapState('preferences', ['theme', 'sidebarAnimating', 'sidebarExpanded']),
@@ -240,7 +189,7 @@
       },
     },
     mounted() {
-      this.$tours.introductionTour.start()
+      this.$tours.introduction.start()
       this.setGeographicalScope('global')
 
       auth

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -88,76 +88,74 @@
       VMapboxInfoTextLayer,
       Sidebar,
     },
-    data() {
-      return {
-        mapboxAccessToken: process.env.MAPBOX_ACCESS_TOKEN,
-        locationsLayers: [],
-        activeLocation: null,
-        geometry: {
-          type: 'Point',
-          coordinates: [],
+    data: () => ({
+      mapboxAccessToken: process.env.MAPBOX_ACCESS_TOKEN,
+      locationsLayers: [],
+      activeLocation: null,
+      geometry: {
+        type: 'Point',
+        coordinates: [],
+      },
+      infoTextGeometry: {
+        type: 'Point',
+        coordinates: [],
+      },
+      mapboxMessage: '',
+      introductionOptions: {
+        useKeyboardNavigation: true,
+      },
+      introductionSteps: [
+        {
+          target: '[data-v-step="1"]',
+          content: 'Welcome to BlueEarth Data!',
+          params: {
+            placement: 'right',
+          },
         },
-        infoTextGeometry: {
-          type: 'Point',
-          coordinates: [],
+        {
+          target: '[data-v-step="2"]',
+          content: 'BlueEarth Data is organized by theme.',
+          params: {
+            placement: 'right',
+          },
         },
-        mapboxMessage: '',
-        introductionOptions: {
-          useKeyboardNavigation: true,
+        {
+          target: '[data-v-step="3"]',
+          content: 'Datasets for each theme are listed here.',
+          params: {
+            placement: 'left',
+          },
         },
-        introductionSteps: [
-          {
-            target: '[data-v-step="1"]',
-            content: 'Welcome to BlueEarth Data!',
-            params: {
-              placement: 'right',
-            },
+        {
+          target: '[data-v-step="4"]',
+          content: 'Toggle spatial maps and time series for each dataset.',
+          params: {
+            placement: 'bottom',
           },
-          {
-            target: '[data-v-step="2"]',
-            content: 'BlueEarth Data is organized by theme.',
-            params: {
-              placement: 'right',
-            },
+        },
+        {
+          target: '[data-v-step="5"]',
+          content: 'Click on a data point on the map to see more details.',
+          params: {
+            placement: 'bottom',
           },
-          {
-            target: '[data-v-step="3"]',
-            content: 'Datasets for each theme are listed here.',
-            params: {
-              placement: 'left',
-            },
+        },
+        {
+          target: '[data-v-step="6"]',
+          content: 'You can download data if you are registered and logged in.',
+          params: {
+            placement: 'right',
           },
-          {
-            target: '[data-v-step="4"]',
-            content: 'Toggle spatial maps and time series for each dataset.',
-            params: {
-              placement: 'bottom',
-            },
+        },
+        {
+          target: '[data-v-step="6"]',
+          content: 'Have fun!',
+          params: {
+            placement: 'right',
           },
-          {
-            target: '[data-v-step="5"]',
-            content: 'Click on a data point on the map to see more details.',
-            params: {
-              placement: 'bottom',
-            },
-          },
-          {
-            target: '[data-v-step="6"]',
-            content: 'You can download data if you are registered and logged in.',
-            params: {
-              placement: 'right',
-            },
-          },
-          {
-            target: '[data-v-step="6"]',
-            content: 'Have fun!',
-            params: {
-              placement: 'right',
-            },
-          },
-        ],
-      }
-    },
+        },
+      ],
+    }),
     computed: {
       ...mapState('preferences', ['theme', 'sidebarAnimating', 'sidebarExpanded']),
       ...mapState('map', ['activeLocationIds', 'loadingRasterLayers']),

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -13,6 +13,7 @@
         :access-token="mapboxAccessToken"
         :preserve-drawing-buffer="true"
         map-style="mapbox://styles/global-data-viewer/cjtss3jfb05w71fmra13u4qqm"
+        data-v-step="5"
       >
         <v-mapbox-navigation-control :options="{ visualizePitch: true }" position="bottom-right" />
         <v-mapbox-selected-point-layer :geometry="geometry" />
@@ -87,27 +88,90 @@
       VMapboxInfoTextLayer,
       Sidebar,
     },
-    data: () => ({
-      mapboxAccessToken: process.env.MAPBOX_ACCESS_TOKEN,
-      locationsLayers: [],
-      activeLocation: null,
-      geometry: {
-        type: 'Point',
-        coordinates: [],
-      },
-      infoTextGeometry: {
-        type: 'Point',
-        coordinates: [],
-      },
-      mapboxMessage: '',
-    }),
+    data() {
+      return {
+        mapboxAccessToken: process.env.MAPBOX_ACCESS_TOKEN,
+        locationsLayers: [],
+        activeLocation: null,
+        geometry: {
+          type: 'Point',
+          coordinates: [],
+        },
+        infoTextGeometry: {
+          type: 'Point',
+          coordinates: [],
+        },
+        mapboxMessage: '',
+        introductionCallbacks: {
+          onNextStep: this.stepCallback,
+          onPreviousStep: this.stepCallback,
+          onFinish: this.finishCallback,
+        },
+        introductionOptions: {
+          useKeyboardNavigation: true,
+          labels: {
+            buttonSkip: 'Skip introduction',
+          },
+        },
+        introductionSteps: [
+          {
+            target: '[data-v-step="1"]',
+            content: 'Welcome to BlueEarth Data!',
+            params: {
+              placement: 'right',
+            },
+          },
+          {
+            target: '[data-v-step="2"]',
+            content: 'BlueEarth Data is organized by theme.',
+            params: {
+              placement: 'right',
+            },
+          },
+          {
+            target: '[data-v-step="3"]',
+            content: 'Datasets for each theme are listed here.',
+            params: {
+              placement: 'left',
+            },
+          },
+          {
+            target: '[data-v-step="4"]',
+            content: 'Toggle spatial maps and time series for each dataset.',
+            params: {
+              placement: 'bottom',
+            },
+          },
+          {
+            target: '[data-v-step="5"]',
+            content: 'Click on a data point on the map to see more details.',
+            params: {
+              placement: 'bottom',
+            },
+          },
+          {
+            target: '[data-v-step="6"]',
+            content: 'You can download data if you are registered and logged in.',
+            params: {
+              placement: 'bottom',
+            },
+          },
+          {
+            target: '[data-v-step="6"]',
+            content: 'Have fun!',
+            params: {
+              placement: 'bottom',
+            },
+          },
+        ],
+      }
+    },
     computed: {
       ...mapState('preferences', ['theme', 'sidebarAnimating', 'sidebarExpanded']),
       ...mapState('map', ['activeLocationIds', 'loadingRasterLayers']),
       ...mapGetters('map', [
         'activeRasterData',
         'activeFlowmapData',
-
         'activeVectorData',
         'activeDatasetsLocations',
         'datasetsInActiveTheme',
@@ -190,6 +254,9 @@
       },
     },
     mounted() {
+      this.$tours.introductionTour.start()
+      this.setGeographicalScope('global')
+
       auth
         .getUser()
         .then(user => {
@@ -202,7 +269,6 @@
         .catch(err => {
           console.log({ err })
         })
-      this.setGeographicalScope('global')
     },
     methods: {
       ...mapMutations('map', [
@@ -215,6 +281,18 @@
           type: 'Point',
           coordinates: [],
         }
+      },
+      stepCallback(step) {
+        if (step === 2) {
+          this.$router.push({ path: '/wl' })
+        }
+
+        if (step === 3) {
+          this.$router.push({ path: '/wl/diva_idp_med_10' })
+        }
+      },
+      finishCallback() {
+        this.$router.push({ path: '/' })
       },
       updateFilter(layer) {
         // if there is a filterIds, concatenate the values into filter

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -48,6 +48,12 @@
     <sidebar />
 
     <disclaimer-modal />
+
+    <v-tour
+      name="introductionTour"
+      :steps="introductionSteps"
+      :callbacks="introductionCallbacks"
+    ></v-tour>
   </div>
 </template>
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -57,6 +57,7 @@ export default {
     '~/css/transitions.css',
     '~/css/typography.css',
     '~/css/markdown.css',
+    '~/css/tour.css',
   ],
 
   /*

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -51,6 +51,7 @@ export default {
   css: [
     'mapbox-gl/dist/mapbox-gl.css',
     'material-design-icons/iconfont/material-icons.css',
+    'vue-tour/dist/vue-tour.css',
     '~/css/main.css',
     '~/css/helpers.css',
     '~/css/transitions.css',
@@ -68,6 +69,7 @@ export default {
     { src: '~/plugins/polyfills', ssr: false },
     { src: '~/plugins/vuelidate', ssr: false },
     { src: '~/plugins/vue-gtag', ssr: false },
+    { src: '~/plugins/vue-tour', ssr: false },
   ],
 
   /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -12971,6 +12971,11 @@
         "verror": "1.10.0"
       }
     },
+    "jump.js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jump.js/-/jump.js-1.0.2.tgz",
+      "integrity": "sha1-4GQbR/QKOPITnCX9oFAL8o5DAVo="
+    },
     "katex": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.6.0.tgz",
@@ -14807,6 +14812,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.0.1.tgz",
       "integrity": "sha1-1Ztk6P7kHElFiqyCtWcYxZV7Kvc="
+    },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -19106,6 +19116,17 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
+    },
+    "vue-tour": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vue-tour/-/vue-tour-1.4.0.tgz",
+      "integrity": "sha512-vsuxNLsSSKBOJpDme1ZkcY744LYk+l4TSfQz39xJZ4BE1GrioyTzS4+PT3D1nKhT/3vOZurNM66cZgzgRNZ/wA==",
+      "requires": {
+        "hash-sum": "^2.0.0",
+        "jump.js": "^1.0.2",
+        "popper.js": "^1.16.0",
+        "vue": "^2.6.10"
+      }
     },
     "vue2mapbox-gl": {
       "version": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "vue-echarts": "^4.1.0",
     "vue-gtag": "^1.6.2",
     "vue-markdown": "^2.2.4",
+    "vue-tour": "^1.4.0",
     "vue2mapbox-gl": "^0.12.0",
     "vuelidate": "^0.7.5",
     "vuex": "^3.1.3",

--- a/plugins/vue-tour.js
+++ b/plugins/vue-tour.js
@@ -1,0 +1,4 @@
+import Vue from 'vue'
+import VueTour from 'vue-tour'
+
+Vue.use(VueTour)

--- a/plugins/vue-tour.js
+++ b/plugins/vue-tour.js
@@ -8,42 +8,44 @@ export const tourConfig = {
 export const tourSteps = [
   {
     target: '[data-v-step="1"]',
-    content: 'Welcome to BlueEarth Data!',
+    content: 'Welcome to <strong>BlueEarth Data</strong>!',
     params: {
       placement: 'right',
     },
   },
   {
     target: '[data-v-step="2"]',
-    content: 'BlueEarth Data is organized by theme.',
+    content: 'BlueEarth Data is organized by <strong>theme</strong>.',
     params: {
       placement: 'right',
     },
   },
   {
     target: '[data-v-step="3"]',
-    content: 'Datasets for each theme are listed here.',
+    content: '<strong>Datasets</strong> for each theme are listed here.',
     params: {
       placement: 'left',
     },
   },
   {
     target: '[data-v-step="4"]',
-    content: 'Toggle spatial maps and time series for each dataset.',
+    content:
+      'Toggle <strong>spatial maps</strong> and <strong>time series</strong> for each dataset.',
     params: {
       placement: 'bottom',
     },
   },
   {
     target: '[data-v-step="5"]',
-    content: 'Click on a data point on the map to see more details.',
+    content: 'Click on a <strong>data point</strong> on the map to see more details.',
     params: {
       placement: 'bottom',
     },
   },
   {
     target: '[data-v-step="6"]',
-    content: 'You can download data if you are registered and logged in.',
+    content:
+      'You can download data if you are <strong>registered</strong> and <strong>logged in</strong>.',
     params: {
       placement: 'right',
     },

--- a/plugins/vue-tour.js
+++ b/plugins/vue-tour.js
@@ -1,4 +1,60 @@
 import Vue from 'vue'
 import VueTour from 'vue-tour'
 
+export const tourConfig = {
+  useKeyboardNavigation: true,
+}
+
+export const tourSteps = [
+  {
+    target: '[data-v-step="1"]',
+    content: 'Welcome to BlueEarth Data!',
+    params: {
+      placement: 'right',
+    },
+  },
+  {
+    target: '[data-v-step="2"]',
+    content: 'BlueEarth Data is organized by theme.',
+    params: {
+      placement: 'right',
+    },
+  },
+  {
+    target: '[data-v-step="3"]',
+    content: 'Datasets for each theme are listed here.',
+    params: {
+      placement: 'left',
+    },
+  },
+  {
+    target: '[data-v-step="4"]',
+    content: 'Toggle spatial maps and time series for each dataset.',
+    params: {
+      placement: 'bottom',
+    },
+  },
+  {
+    target: '[data-v-step="5"]',
+    content: 'Click on a data point on the map to see more details.',
+    params: {
+      placement: 'bottom',
+    },
+  },
+  {
+    target: '[data-v-step="6"]',
+    content: 'You can download data if you are registered and logged in.',
+    params: {
+      placement: 'right',
+    },
+  },
+  {
+    target: '[data-v-step="6"]',
+    content: 'Have fun!',
+    params: {
+      placement: 'right',
+    },
+  },
+]
+
 Vue.use(VueTour)

--- a/test/unit/layouts/default.spec.js
+++ b/test/unit/layouts/default.spec.js
@@ -98,6 +98,7 @@ describe('Default', () => {
       mocks: {
         $route: { params: { datasetIds: 'cd' }, name: 'datasetIds-locationId' },
         $router: { push: routerPush },
+        $tours: { introduction: { start: jest.fn() } },
       },
     })
 
@@ -120,6 +121,7 @@ describe('Default', () => {
           name: 'datasetIds-locationId',
         },
         $router: { push: routerPush },
+        $tours: { introduction: { start: jest.fn() } },
       },
     })
 
@@ -142,6 +144,7 @@ describe('Default', () => {
           name: 'datasetIds-locationId',
         },
         $router: { push: routerPush },
+        $tours: { introduction: { start: jest.fn() } },
       },
     })
 


### PR DESCRIPTION
This pull-request includes:
- Added `vue-tour` as a depencency.
- Setup tour in `default.vue` view.
- Added the steps throughout the protect.
  - Adjusted route to spawn the `ui-tray` component` for one of the steps.
  - Return to root on tour finish.

Note: No styling is changed for the `vue-tour` tooltip. This can be done later.